### PR TITLE
fix: Fix some aspects of the schema

### DIFF
--- a/src/editor/schema.ts
+++ b/src/editor/schema.ts
@@ -20,9 +20,6 @@ const nodes: { [name: string]: NodeSpec } = {
     text: {
         inline: true, // text is inline by default
         group: "inline",
-        toDOM(node) {
-            return node.text || ""
-        },
     },
 
     paragraph: {
@@ -78,7 +75,7 @@ const nodes: { [name: string]: NodeSpec } = {
         parseDOM: [
             {
                 tag: "pre",
-                preserveWhitespace: true,
+                preserveWhitespace: "full",
                 getAttrs: buildGetAttrs(dom => ({
                     language: dom.getAttribute("data-language") || "",
                 })),


### PR DESCRIPTION
Code blocks in the schema no longer allow marks inside them.

Code blocks are now parsed with `preserveWhiteSpace: full`,
preventing removal of newline characters.

Merge from prosemirror-markdown/commit/64ba629987b17ab1b82098a1bc890cf4b1f33deb