### PR TITLE
fix(editor): add syntax highlighting support for more languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@remirror/core": "^0.11.0",
     "@remirror/core-extensions": "^0.11.0",
     "@remirror/dev": "^0.11.0",
-    "@remirror/extension-code-block": "^0.11.0",
+    "@remirror/extension-code-block": "^0.12.0",
     "@remirror/extension-tables": "^0.11.0",
     "@remirror/react": "^0.11.0",
     "@types/expect-puppeteer": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2532,10 +2532,10 @@
     "@types/prosemirror-dev-tools" "^2.1.0"
     prosemirror-dev-tools "^2.1.1"
 
-"@remirror/extension-code-block@^0.11.0":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@remirror/extension-code-block/-/extension-code-block-0.11.1.tgz#3c89e36c7a9e2e9638464b994244b8d41cb188a7"
-  integrity sha512-YkJ8dDbKGs7YNt8zXDayOEQgpWxqZ/CDRWzqfDuuP7mAPZU0j8S1JqHG5krhJNN7aZhIDUvMHXXn314T78SnZg==
+"@remirror/extension-code-block@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@remirror/extension-code-block/-/extension-code-block-0.12.0.tgz#29869c0bdeba608f46797092b62358948cd5822f"
+  integrity sha512-EY6jrTK+u2MYM66sXpGTOPVzx+LzbrnWrantSU3P3pzBLuDerPh3jO1GGOQl3qT1qp/VUfRMtZG/dvzd5JIs/A==
   dependencies:
     "@babel/runtime" "^7"
     "@remirror/core" "^0.11.0"


### PR DESCRIPTION
Including `json5`, `JSON`, `YML` and `YAML`.

See also: https://github.com/remirror/remirror/pull/281