### PR TITLE
chore(deps): remove a conflicting dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "jest-transform-stub": "^2.0.0",
         "js-yaml": "^4.1.0",
         "playwright-chromium": "^1.13.0",
-        "playwright-core": "^1.13.0",
         "prettier": "^2.3.2",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.4",

--- a/packages/editor/e2e/utils.ts
+++ b/packages/editor/e2e/utils.ts
@@ -1,5 +1,5 @@
 import os from "os"
-import { Dialog, ElementHandle } from "playwright-core"
+import { Dialog, ElementHandle } from "playwright-chromium"
 
 page.setDefaultTimeout(5000)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,6 @@ importers:
       jest-transform-stub: ^2.0.0
       js-yaml: ^4.1.0
       playwright-chromium: ^1.13.0
-      playwright-core: ^1.13.0
       prettier: ^2.3.2
       rimraf: ^3.0.2
       ts-jest: ^27.0.4
@@ -55,7 +54,6 @@ importers:
       jest-transform-stub: 2.0.0
       js-yaml: 4.1.0
       playwright-chromium: 1.13.0
-      playwright-core: 1.13.0
       prettier: 2.3.2
       rimraf: 3.0.2
       ts-jest: 27.0.4_52cc4273aa16028085013af47e479e10


### PR DESCRIPTION
This PR fixes the following error:

```
Cannot link binary 'playwright' of 'playwright-core' to '/code/rino/node_modules/.bin': binary of 'playwright-chromium' is already linked
```