### PR TITLE
chore: fix the development workflow for node.js v17

### DIFF
--- a/jest-playwright.config.js
+++ b/jest-playwright.config.js
@@ -14,6 +14,7 @@ const config = {
         launchTimeout: 120 * 1000,
         debug: true,
         protocol: "http-get",
+        host: "127.0.0.1", // Node.js v17+ will resolve localhost to ipv6 ::1 instead of 127.0.0.1
         waitOnScheme: {
             verbose: false,
             interval: 1000,

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -6,7 +6,7 @@
     "author": "ocavue",
     "description": "A better way to write Markdown",
     "scripts": {
-        "dev": "./setup.sh && NODE_ENV=development electron .",
+        "dev": "./setup.sh && wait-on --timeout 60000 tcp:127.0.0.1:3004 && NODE_ENV=development electron .",
         "build": "./setup.sh && electron-builder -p never",
         "build:dir": "./setup.sh && electron-builder -p never --dir",
         "build:all": "./setup.sh && electron-builder -p never --mac --win --linux"


### PR DESCRIPTION
Node.js v17 will resolve "localhost" as IPv6 address `::1` instead of `127.0.0.1`. This causes some issues when using `jest-playwright` and `wait-on`. Fixed it by explicitly setting `host` to `127.0.0.1`.

See also:

https://github.com/jeffbski/wait-on/issues/109
https://github.com/nodejs/node/pull/39987
https://github.com/nodejs/node/issues/40537