### PR TITLE
fix(editor): adjust the language menu position

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -35,6 +35,7 @@
         "@codemirror/view": "^0.19.39",
         "@emotion/css": "^11.7.1",
         "@emotion/react": "^11.7.1",
+        "@floating-ui/dom": "^0.1.10",
         "@mui/material": "^5.2.7",
         "@remirror/core": "^1.3.3",
         "@remirror/core-utils": "^1.1.4",

--- a/packages/editor/playground/playground.tsx
+++ b/packages/editor/playground/playground.tsx
@@ -33,6 +33,13 @@ const longContent = (
     `hello **strong**! hello *italic*! hello \`code\`! hello [link](https://www.google.com)! `.repeat(200) + "\n\n"
 ).repeat(5)
 
+const justCodeContent = `
+\`\`\`python
+while True:
+    print("hello world")
+\`\`\`
+`.trim()
+
 /** focus this element to hide the cursor in the editor */
 const BlurHelper: FC = () => {
     return (
@@ -73,6 +80,8 @@ const App: FC = () => {
             content = initialContent
         } else if (initialContentId === "long") {
             content = longContent
+        } else if (initialContentId === "just-code") {
+            content = justCodeContent
         }
 
         return {

--- a/packages/editor/src/components/theme/github.ts
+++ b/packages/editor/src/components/theme/github.ts
@@ -506,6 +506,9 @@ export const EDITOR_THEME_GITHUB = css`
         padding: 8px 12px;
         border-radius: 4px;
     }
+    & .cm-editor.cm-focused {
+        outline: none; // override the default outline
+    }
 
     & .language-menu {
         width: auto;
@@ -520,7 +523,6 @@ export const EDITOR_THEME_GITHUB = css`
         position: absolute;
         min-width: 50px;
         height: 16px;
-        margin: 4px 0px;
         padding: 8px;
     }
 

--- a/packages/editor/src/extensions/codemirror/code-mirror-const.ts
+++ b/packages/editor/src/extensions/codemirror/code-mirror-const.ts
@@ -1,0 +1,2 @@
+/** Use this fake language name to mark a code block as an indented code block instead of a fence code block */
+export const fakeIndentedLanguage = "rino-indented"

--- a/packages/editor/src/extensions/codemirror/index.ts
+++ b/packages/editor/src/extensions/codemirror/index.ts
@@ -1,2 +1,3 @@
-export * from "./codemirror-extension"
+export { RinoCodeMirrorExtension } from "./codemirror-extension"
 export { buildCodeMirrorOptions } from "./codemirror-options"
+export { fakeIndentedLanguage } from "./code-mirror-const"

--- a/packages/editor/src/extensions/inline/index.ts
+++ b/packages/editor/src/extensions/inline/index.ts
@@ -1,5 +1,5 @@
 export * from "./inline-deco-plugin"
 export * from "./inline-mark-extensions"
 export { RinoInlineMarkExtension } from "./inline-mark-plugin"
-export { applyRangeMarks, applyNodeMarks, updateNodeMarks } from "./inline-mark-helpers"
+export { applyRangeMarks, updateNodeMarks } from "./inline-mark-helpers"
 export * from "./inline-types"

--- a/packages/editor/src/extensions/inline/inline-mark-helpers.ts
+++ b/packages/editor/src/extensions/inline/inline-mark-helpers.ts
@@ -142,26 +142,14 @@ export function updateNodeMarks<S extends Schema>(tr: Transform<S>, node: Node<S
 }
 
 /**
- * Parse the text content from a Prosemirror node and dispatch a transaction to apply markdown marks to this Node.
- *
- * @param view The EditorView object
- * @param node The Prosemirror node to parse
- * @param startPos The (absolute) position at the start of the node
- */
-export function applyNodeMarks<S extends Schema>(view: EditorView<S>, node: Node<S>, startPos: number) {
-    const tr = view.state.tr.setMeta("RINO_APPLY_MARKS", true)
-    const oldSelection = tr.selection
-    updateNodeMarks(tr, node, startPos)
-    if (tr.docChanged) {
-        tr.setSelection(oldSelection.map(tr.doc, unchangedMappable))
-        view.dispatch(tr)
-    }
-}
-
-/**
  * Apply markdown marks to current selection range.
  */
 export function applyRangeMarks<S extends Schema>(view: EditorView<S>): void {
+    // @ts-expect-error This will be fixed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58084
+    if (view.isDestroyed) {
+        return
+    }
+
     const tr = view.state.tr
     if (updateRangeMarks(tr)) {
         view.dispatch(tr)

--- a/packages/editor/src/extensions/inline/inline-mark-plugin.ts
+++ b/packages/editor/src/extensions/inline/inline-mark-plugin.ts
@@ -4,7 +4,7 @@ import { EditorView } from "prosemirror-view"
 
 import { applyRangeMarks, updateRangeMarks } from "./inline-mark-helpers"
 
-function createInlineMarkPlugin(isUnitTest = false, isDestroyedRef: { val: boolean }): PluginSpec {
+function createInlineMarkPlugin(isUnitTest = false): PluginSpec {
     let timeoutId: ReturnType<typeof setTimeout> | null = null
 
     const debounceApplyMarks: (view: EditorView) => void = isUnitTest
@@ -14,9 +14,7 @@ function createInlineMarkPlugin(isUnitTest = false, isDestroyedRef: { val: boole
                   clearTimeout(timeoutId)
               }
               timeoutId = setTimeout(() => {
-                  if (!isDestroyedRef.val) {
-                      applyRangeMarks(view)
-                  }
+                  applyRangeMarks(view)
                   timeoutId = null
               }, 100)
           }
@@ -56,12 +54,10 @@ function createInlineMarkPlugin(isUnitTest = false, isDestroyedRef: { val: boole
 export class RinoInlineMarkExtension extends PlainExtension {
     // The editor will not "debounce" when `#testing` is true. Used in unit tests.
     private isUnitTest: boolean
-    private isDestroyedRef: { val: boolean }
 
     public constructor(isUnitTest = false) {
         super()
         this.isUnitTest = isUnitTest
-        this.isDestroyedRef = { val: false }
     }
 
     get name() {
@@ -75,10 +71,6 @@ export class RinoInlineMarkExtension extends PlainExtension {
     }
 
     createPlugin() {
-        return createInlineMarkPlugin(this.isUnitTest, this.isDestroyedRef)
-    }
-
-    onDestroy() {
-        this.isDestroyedRef.val = true
+        return createInlineMarkPlugin(this.isUnitTest)
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,7 @@ importers:
       '@codemirror/view': ^0.19.39
       '@emotion/css': ^11.7.1
       '@emotion/react': ^11.7.1
+      '@floating-ui/dom': ^0.1.10
       '@mui/material': ^5.2.7
       '@remirror/core': ^1.3.3
       '@remirror/core-utils': ^1.1.4
@@ -159,6 +160,7 @@ importers:
       '@codemirror/view': 0.19.39
       '@emotion/css': 11.7.1_@babel+core@7.16.7
       '@emotion/react': 11.7.1_b3e67f1b1cc68ee82c343add0615c039
+      '@floating-ui/dom': 0.1.10
       '@mui/material': 5.2.7_0a8ca8f054376b7dddf1c4bce58adb4b
       '@remirror/core': 1.3.3_faa36c6b4392e5b76d566689f25c17a2
       '@remirror/core-utils': 1.1.4_faa36c6b4392e5b76d566689f25c17a2
@@ -1262,6 +1264,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@floating-ui/core/0.3.1:
+    resolution: {integrity: sha512-ensKY7Ub59u16qsVIFEo2hwTCqZ/r9oZZFh51ivcLGHfUwTn8l1Xzng8RJUe91H/UP8PeqeBronAGx0qmzwk2g==}
+    dev: false
+
+  /@floating-ui/dom/0.1.10:
+    resolution: {integrity: sha512-4kAVoogvQm2N0XE0G6APQJuCNuErjOfPW8Ux7DFxh8+AfugWflwVJ5LDlHOwrwut7z/30NUvdtHzQ3zSip4EzQ==}
+    dependencies:
+      '@floating-ui/core': 0.3.1
+    dev: false
 
   /@hapi/accept/5.0.2:
     resolution: {integrity: sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==}
@@ -8944,6 +8956,7 @@ packages:
       chalk: 2.4.2
       diff-match-patch: 1.0.5
     dev: false
+    bundledDependencies: []
 
   /jsonfile/4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}


### PR DESCRIPTION
When the code block is the first node in the doc, the language menu will overflow. This PR fixes this issue. 

![image](https://user-images.githubusercontent.com/24715727/148905984-116776a6-445a-4338-9fef-b8e0a9454da3.png)
